### PR TITLE
feat(observability): add kube-prometheus-stack monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Welcome to my personal homelab Kubernetes infrastructure repository! This is a p
 - **Longhorn**: Distributed block storage with replication
 - **Storage Classes**: Automated volume provisioning
 
+### Monitoring (`monitoring`)
+- **kube-prometheus-stack**: Prometheus Operator with Prometheus, Alertmanager, Grafana, and exporters
+
 ### Applications (`default`)
 - **Echo**: HTTP echo service for testing and health checks
 - **PostgreSQL**: Database with persistent storage
@@ -155,6 +158,22 @@ kubectl get events -n <namespace> --sort-by='.metadata.creationTimestamp'
 ```
 
 ## 📊 Monitoring & Observability
+
+kube-prometheus-stack aggregates Prometheus, Alertmanager, Grafana, kube-state-metrics, and node-exporter for full-cluster metrics and dashboards. The stack is deployed via Flux from the `prometheus-community/kube-prometheus-stack` chart pinned at version 77.1.0.
+
+### Access via Tailscale
+- **Grafana**: `http://grafana` (tailnet)
+- **Prometheus**: `http://prometheus`
+- **Alertmanager**: `http://alertmanager`
+Access is restricted via Tailscale ACLs.
+
+### Validation
+1. Verify Prometheus targets include `kubernetes-apiservers`, `kubelet`, `node-exporter`, and `kube-state-metrics`.
+2. Confirm Grafana and Alertmanager UIs load at their hostnames.
+3. _TODO_: add sanitized Grafana dashboard screenshots.
+
+### Next Steps
+- Integrate Gatekeeper and Falco dashboards and ServiceMonitors.
 
 ### Metrics Collection
 - **Metrics Server**: Kubernetes resource metrics

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-config.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-config.sops.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-config
+  namespace: monitoring
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    route:
+      receiver: 'null'
+    receivers:
+      - name: 'null'
+    # TODO: configure real receivers
+sops:
+  age:
+    - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArdWFMS2JiZmMwUk8yTTI3
+        U3VxbWxLMWk3UVRmQ2dIMk5wYStXeWtXblQwCjlxUU5iWEdGYy8rT0tYYXErWTV4
+        ckRxZjQvWGVVOFNaNTEyTTU4YUZHSTAKLS0tIEcwNzFSRjVkWVV0dkY1Vkkzb2FD
+        STJvbkRTbXovNDRDaHpINitPMHJ4SncKEWSs6/UefNZV4yuHiT2K7LCe2vlYNXRt
+        YXzH0V/TXs44p6wbnxOlBGfAhWV4ijcpnKOYbxWbMdae2awgIyuRUQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-08-21T17:16:59Z"
+  mac: ENC[AES256_GCM,data:oF1gFq1I64kTk+Qnq10AaVcdOU1F0B0hAQQ65beJtKMtBG3a1fRSmN6sXrvjb4Vi5DJUCbNBLihGQBzM4KEZpDYpv8xJCrJIegPeS02SXs6WsK8Jiehn6rapWlDdLIKmlnA9UAM2iC1TIewIRwj48yeaYpQOpcef4YhSG+clQtM=,iv:MjVdZ0mkapfwF9J41UOT2Lro1lKpubvyPgwwztiKyUg=,tag:TBZSIJnIU7Hob6y9lCF2ow==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-admin.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-admin.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin
+  namespace: monitoring
+type: Opaque
+stringData:
+  admin-user: ENC[AES256_GCM,data:Z8JvC65+U+FWhKq1o/El1KI=,iv:nZKJeuh1n3wzcnV4PUo7bEZYgd61ZygHatz/itVb0fU=,tag:dGW/IIH6pfTOQ/JqS7/qjA==,type:str]
+  admin-password: ENC[AES256_GCM,data:e6z6++EyhDZSu2QQupiKLl9+u6tY6cp3glRWDpHiLoxqOMrk9/3pQ+JdiCl+TpK7/yjiL5imCn6/+vRiRNeG,iv:LHEnjFZqDOP5E8o+rExzbNqth8SKD4VwLTerY7bU86M=,tag:H5aRI8dbHUdNDKErULdFmQ==,type:str]
+sops:
+  age:
+    - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArdWFMS2JiZmMwUk8yTTI3
+        U3VxbWxLMWk3UVRmQ2dIMk5wYStXeWtXblQwCjlxUU5iWEdGYy8rT0tYYXErWTV4
+        ckRxZjQvWGVVOFNaNTEyTTU4YUZHSTAKLS0tIEcwNzFSRjVkWVV0dkY1Vkkzb2FD
+        STJvbkRTbXovNDRDaHpINitPMHJ4SncKEWSs6/UefNZV4yuHiT2K7LCe2vlYNXRt
+        YXzH0V/TXs44p6wbnxOlBGfAhWV4ijcpnKOYbxWbMdae2awgIyuRUQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-08-21T17:16:59Z"
+  mac: ENC[AES256_GCM,data:oF1gFq1I64kTk+Qnq10AaVcdOU1F0B0hAQQ65beJtKMtBG3a1fRSmN6sXrvjb4Vi5DJUCbNBLihGQBzM4KEZpDYpv8xJCrJIegPeS02SXs6WsK8Jiehn6rapWlDdLIKmlnA9UAM2iC1TIewIRwj48yeaYpQOpcef4YhSG+clQtM=,iv:MjVdZ0mkapfwF9J41UOT2Lro1lKpubvyPgwwztiKyUg=,tag:TBZSIJnIU7Hob6y9lCF2ow==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helm/values.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helm/values.yaml
@@ -1,0 +1,65 @@
+---
+grafana:
+  admin:
+    existingSecret: grafana-admin
+    userKey: admin-user
+    passwordKey: admin-password
+  service:
+    type: LoadBalancer
+    loadBalancerClass: tailscale
+    annotations:
+      tailscale.com/hostname: grafana
+    port: 80
+  ingress:
+    enabled: false
+
+prometheus:
+  service:
+    type: LoadBalancer
+    loadBalancerClass: tailscale
+    annotations:
+      tailscale.com/hostname: prometheus
+    port: 9090
+  ingress:
+    enabled: false
+  prometheusSpec:
+    retention: 7d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: longhorn
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 20Gi
+    # remoteWrite:
+    #   - url: https://example.com/prom/push
+    #     # TODO: configure remote write (Grafana Cloud/Thanos/Mimir)
+
+alertmanager:
+  service:
+    type: LoadBalancer
+    loadBalancerClass: tailscale
+    annotations:
+      tailscale.com/hostname: alertmanager
+    port: 9093
+  ingress:
+    enabled: false
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: longhorn
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 20Gi
+    configSecret: alertmanager-config
+
+kubeStateMetrics:
+  enabled: true
+
+nodeExporter:
+  enabled: true
+
+# TODO: add Gatekeeper ServiceMonitor when Gatekeeper is deployed

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+# yamllint enable rule:line-length
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: monitoring
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts
+---
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+# yamllint enable rule:line-length
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kube-prometheus-stack
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: *app
+      version: 77.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: monitoring
+  install:
+    createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: kube-prometheus-stack-values

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./grafana-admin.sops.yaml
+  - ./alertmanager-config.sops.yaml
+configMapGenerator:
+  - name: kube-prometheus-stack-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kube-prometheus-stack
+  namespace: &namespace monitoring
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+    - name: longhorn
+      namespace: longhorn-system
+    - name: tailscale-operator
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/kube-prometheus-stack/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+components:
+  - ../../components/common
+resources:
+  - ./kube-prometheus-stack/ks.yaml


### PR DESCRIPTION
## Summary
- deploy kube-prometheus-stack via Flux pinned to chart `77.1.0`
- expose Grafana, Prometheus, and Alertmanager UIs through Tailscale LoadBalancer services backed by Longhorn storage
- document monitoring access and validation steps

## Testing
- `kubectl apply --dry-run=client --validate=false -R -f kubernetes/` *(fails: could not connect to Kubernetes API)*
- `yamllint kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml`

## Upstream Reference
- https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

------
https://chatgpt.com/codex/tasks/task_e_68b249593e4883338f63c4cef9f66c82