### PR TITLE
monitoring(prometheus): use Longhorn PVC (20Gi) + 15d retention, 20GiB cap, 30s interval

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -34,21 +34,21 @@ spec:
   values:
     # Global configuration
     global:
-      # Use synology-csi storage class
-      storageClass: "synology-iscsi-delete"
+      # Use longhorn storage class
+      storageClass: "longhorn"
 
     # Prometheus configuration
     prometheus:
       prometheusSpec:
-        # Use synology-csi for persistent storage
+        # Use longhorn for persistent storage
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: synology-iscsi-delete
+              storageClassName: longhorn
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
-                  storage: 50Gi
+                  storage: 20Gi
 
         # Resource limits for homelab
         resources:
@@ -60,8 +60,9 @@ spec:
             cpu: 500m
 
         # Retention and scrape intervals
-        retention: 7d
-        scrapeInterval: 30s
+        retention: 15d
+        retentionSize: 20GiB
+        scrapeInterval: "30s"
         evaluationInterval: 30s
 
         # Enable service monitors for kube-system components


### PR DESCRIPTION
## Summary
- use Longhorn storage class for Prometheus PVC
- set retention to 15d with 20GiB cap and 30s scrape interval

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 140}}}' kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app`
- `kubectl apply --dry-run=client -k kubernetes/apps/monitoring/kube-prometheus-stack/app` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b9520578833394183711f189a805