### PR TITLE
Check renovate for portfolio image updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -83,6 +83,16 @@
       ignoreTests: true,
     },
     {
+      description: "Auto-merge Portfolio Image Updates",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/yamshy/portfolio"],
+      automerge: true,
+      automergeType: "branch",
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      minimumReleaseAge: "1 day",
+      ignoreTests: true,
+    },
+    {
       matchUpdateTypes: ["major"],
       semanticCommitType: "feat",
       commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -90,7 +90,6 @@
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "1 day",
-      ignoreTests: true,
     },
     {
       matchUpdateTypes: ["major"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -89,7 +89,7 @@
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
-      schedule: ["before 6am on weekdays", "every weekend"],
+      schedule: ["before 6am", "before 6pm"],
     },
     {
       matchUpdateTypes: ["major"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -89,7 +89,7 @@
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
-      minimumReleaseAge: "1 day",
+      schedule: ["before 6am on weekdays", "every weekend"],
     },
     {
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
Add a Renovate package rule to auto-merge minor, patch, and digest updates for the portfolio image (`ghcr.io/yamshy/portfolio`).

---
<a href="https://cursor.com/background-agent?bcId=bc-ca1fe520-aa7e-4a94-a3ef-6a41164edc06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca1fe520-aa7e-4a94-a3ef-6a41164edc06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

