### PR TITLE
feat: switch echo app to Tailscale ingress

### DIFF
--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
@@ -65,12 +65,25 @@ spec:
         ports:
           http:
             port: *port
-        type: LoadBalancer
-        loadBalancerClass: tailscale
     serviceMonitor:
       app:
         endpoints:
           - port: http
+    ingress:
+      app:
+        enabled: true
+        className: tailscale
+        hosts:
+          - host: echo
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - echo
     route:
       app:
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]


### PR DESCRIPTION
## Summary
- expose echo via Tailscale ingress
- drop tailscale load balancer

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' kubernetes/apps/default/echo/app/helmrelease.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68ba2eec914483339d60007cea9c0349