### PR TITLE
docs: add echo service README

### DIFF
--- a/kubernetes/apps/default/echo/README.md
+++ b/kubernetes/apps/default/echo/README.md
@@ -1,0 +1,20 @@
+# Echo Test Service Deployment
+
+This directory contains the HelmRelease and supporting files for deploying a simple HTTP echo service using the `app-template` Helm chart.
+
+## What it deploys
+
+- **Container**: `ghcr.io/mendhak/http-https-echo:37`
+- **Port**: 80 (HTTP)
+- **Security**: Runs as non-root user (`65534`), read-only root filesystem, all capabilities dropped
+- **Health Checks**: Liveness and readiness probes on `/healthz`
+
+## Access
+
+- **Tailscale Ingress**: Exposed internally at `https://echo`
+- **Gateway Route**: Exposed externally via HTTPRoute at `echo.${SECRET_DOMAIN}`
+
+## Monitoring
+
+- **ServiceMonitor**: Metrics are scraped from port `http` for Prometheus
+


### PR DESCRIPTION
## Summary
- document echo test service deployment

## Testing
- `task --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba814a409c8333ab5eab1d32cd3c9c