### PR TITLE
docs: add mise installation instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS
+
+## Setup
+
+This repository uses [mise](https://mise.jdx.dev) to manage all required tools.
+Install mise and run the following commands to set up the toolchain:
+
+```
+mise trust  # trust project configuration
+mise install
+```
+
+These commands install tools such as go-task, kubectl, and others defined in `.mise.toml`.


### PR DESCRIPTION
## Summary
- document requirement to install mise for tool management

## Testing
- `task -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2640090083338d073c20f0a6f062