### PR TITLE
chore(renovate): schedule daily

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -8,25 +8,25 @@
     ":dependencyDashboard",
     ":disableRateLimiting",
     ":semanticCommits",
+    "schedule:daily",
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
-  schedule: ["every weekend"],
   ignorePaths: ["**/*.sops.*"],
   flux: {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
+    fileMatch: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
   },
   "helm-values": {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
+    fileMatch: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
   },
   helmfile: {
-    managerFilePatterns: ["/(^|/)helmfile\\.ya?ml(?:\\.j2)?$/"],
+    fileMatch: ["/(^|/)helmfile\\.ya?ml(?:\\.j2)?$/"],
   },
   kubernetes: {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
+    fileMatch: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
   },
   kustomize: {
-    managerFilePatterns: ["/^kustomization\\.ya?ml(?:\\.j2)?$/"],
+    fileMatch: ["/^kustomization\\.ya?ml(?:\\.j2)?$/"],
   },
   packageRules: [
     {
@@ -171,7 +171,7 @@
     {
       description: "Process annotated dependencies",
       customType: "regex",
-      managerFilePatterns: [
+      fileMatch: [
         "/(^|/).+\\.env(?:\\.j2)?$/",
         "/(^|/).+\\.sh(?:\\.j2)?$/",
         "/(^|/).+\\.ya?ml(?:\\.j2)?$/",

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ task talos:upgrade-k8s
 ```
 
 ### Application Updates
+- **Update Schedule**: Renovate checks for updates daily
 - **Helm Charts**: Automatic updates via Renovate
 - **Container Images**: Automated image updates
 - **Configuration**: Git-based configuration management


### PR DESCRIPTION
## Summary
- run renovate daily
- replace deprecated managerFilePatterns with fileMatch
- document daily schedule in README

## Testing
- `CI=true npx -y -p renovate renovate-config-validator`


------
https://chatgpt.com/codex/tasks/task_e_68bb257585548333a1db57535cc1e2a7