### PR TITLE
feat(agixt): add AGiXT deployment under agents namespace

### DIFF
--- a/kubernetes/apps/agents/agixt/app/configmap.yaml
+++ b/kubernetes/apps/agents/agixt/app/configmap.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agixt-config
+data:
+  DATABASE_TYPE: sqlite
+  DATABASE_NAME: models/agixt
+  UVICORN_WORKERS: "10"
+  AGIXT_URI: https://agixt
+  APP_URI: https://agixt
+  DISABLED_EXTENSIONS: ""
+  DISABLED_PROVIDERS: ""
+  WORKING_DIRECTORY: /agixt/WORKSPACE
+  REGISTRATION_DISABLED: "false"
+  TOKENIZERS_PARALLELISM: "false"
+  LOG_LEVEL: INFO

--- a/kubernetes/apps/agents/agixt/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/agixt/app/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agixt
+  namespace: agents
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      agixt:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/josh-xt/agixt
+              tag: 1.7.14
+            envFrom:
+              - configMapRef:
+                  name: agixt-config
+              - secretRef:
+                  name: agixt-secrets
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 7437
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        enabled: true
+        className: tailscale
+        hosts:
+          - host: agixt
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - agixt

--- a/kubernetes/apps/agents/agixt/app/kustomization.yaml
+++ b/kubernetes/apps/agents/agixt/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/agents/agixt/app/secret.sops.yaml
+++ b/kubernetes/apps/agents/agixt/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agixt-secrets
+  namespace: agents
+type: Opaque
+stringData:
+  AGIXT_API_KEY: ""
+sops:
+  age:
+    - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0cGViVjA3bkJCeW9mUkUy
+        VGszSFBlb0Vqd0hKUkV4MzJwYVdnVkVDUjJzClBHYmVjc2ZzVHdXSUI1OW5ja1Rs
+        RGJpZTJLTlhzMnY4VFZmUDJVYUtqN3MKLS0tIGdvZ1ZzOGdDK25HdFRHeDVBVklN
+        VWFRdU44N2ZhSXVLYjI1WTJjRnhmVWMKtY2SxUjZK/Qe9iXjZw2z1mwvW4pyrJVa
+        Ee56nXUJ8HNIiEW5Z6Y2z2cCNr8F0J0xwfnH2Qmm+A2xQCkpj7coSg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-09-04T00:00:00Z"
+  mac: ENC[AES256_GCM,data:placeholder,iv:placeholder,tag:placeholder,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/agents/agixt/app/secret.sops.yaml
+++ b/kubernetes/apps/agents/agixt/app/secret.sops.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: agents
 type: Opaque
 stringData:
-  AGIXT_API_KEY: ""
+  AGIXT_API_KEY: ENC[AES256_GCM,data:OwdWvczRJwblQtWywmwTyuEW77O9vGovdRajq2XBwY3eA6QnI5qgL3mgva3tp94i4Gzmc4UUWNhqnNdjQNUiUw==,iv:nbI1l2hXSmDopaxQDY3dST674VIZ/uT/F/gW2i9l96Q=,tag:CNEjG5RssjS5G/JvLgRokw==,type:str]
 sops:
   age:
     - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0cGViVjA3bkJCeW9mUkUy
-        VGszSFBlb0Vqd0hKUkV4MzJwYVdnVkVDUjJzClBHYmVjc2ZzVHdXSUI1OW5ja1Rs
-        RGJpZTJLTlhzMnY4VFZmUDJVYUtqN3MKLS0tIGdvZ1ZzOGdDK25HdFRHeDVBVklN
-        VWFRdU44N2ZhSXVLYjI1WTJjRnhmVWMKtY2SxUjZK/Qe9iXjZw2z1mwvW4pyrJVa
-        Ee56nXUJ8HNIiEW5Z6Y2z2cCNr8F0J0xwfnH2Qmm+A2xQCkpj7coSg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYa3hUbkY4MUtXUnRoRHoz
+        WVRpVUNDOEdnejBNb0pjTWFjZjAzc1FLRGxjCncvNU1ZMUNBNmR6VUhkb01mVlR3
+        YkFVNEs3VVdsb1YwQTFOb3laODRVUTgKLS0tIFF6YStrN1Q1YklqQWdEbG1aZlo5
+        bm5OemRoUzhSdXM2SDU2M045Vkhoc0EKlkVFIC+sQNLx4asAmCRrk5puxGwDQ2Lh
+        PK6e9FrRhKeRWgey3/cRyNB70PDQWD5jyzlEhk1XMENHxW50bGCx3g==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-09-04T00:00:00Z"
-  mac: ENC[AES256_GCM,data:placeholder,iv:placeholder,tag:placeholder,type:str]
+  lastmodified: "2025-09-08T16:13:36Z"
+  mac: ENC[AES256_GCM,data:VcBtwV9aq7M5BOKJKIcWmVDy6AE9v5IvbMeXyxT4HE5I9LsOBABX3c9vW8hJk5/fWBMAZT8dzVr+sHi6N/Q4RqjukUpSlvrkk2wHbsSWRwtF/uqPmN/bPRoGreD5K0kMDsmedtrclNGeTyaYm4NWcjXw51maDWIJYKwTHuOJaM0=,iv:O244rXSro3ncKHQKx7TKMoex+IM2lfFbUfYfphWf2zo=,tag:hWobfqMm4JuZn83MqZqEwA==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.10.2

--- a/kubernetes/apps/agents/agixt/ks.yaml
+++ b/kubernetes/apps/agents/agixt/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agixt
+  namespace: &namespace agents
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/agents/agixt/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/agents/kustomization.yaml
+++ b/kubernetes/apps/agents/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+components:
+  - ../../components/common
+resources:
+  - ./agixt/ks.yaml


### PR DESCRIPTION
## Summary
- remove image automation resources for AGiXT
- expose AGiXT solely via Tailscale ingress
- configure APP_URI for Tailscale-host access
- switch AGIXT_URI to HTTPS for tailscale ingress

## Testing
- `mise trust`
- `mise install` *(partial failure: helm archive download)*
- `./scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be3b37b6c08333977236771c05014b