### PR TITLE
Only run GitHub workflows on PRs to main

### DIFF
--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -4,7 +4,6 @@ name: kubeconform-validate
 
 on:
   pull_request:
-  push:
     branches: [main]
 
 env:

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -4,7 +4,7 @@ name: "Label Sync"
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches: ["main"]
     paths: [".github/labels.yaml"]
 


### PR DESCRIPTION
## Summary
- trigger kubeconform validation workflow only on pull requests to `main`
- run label sync action only for `labels.yaml` changes in pull requests to `main`

## Testing
- `mise install` *(fails: HTTP status 403)*
- `task --list`


------
https://chatgpt.com/codex/tasks/task_e_68bf04d66b188333b668270c2996ff83