### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -30,6 +30,8 @@ jobs:
     name: Flux Local Test
     needs: pre-job
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/yamshy/homelab/security/code-scanning/3](https://github.com/yamshy/homelab/security/code-scanning/3)

To fix the problem, we should explicitly specify the `permissions` block for the `test` job, setting it to the minimum required scope. In this case, the job only runs tests using checked out code and does not require write access to repository resources, so it should request only `contents: read`. The change should be applied within the `test` job definition by adding a `permissions:` block with `contents: read` beneath the `runs-on` line (after line 32). This does not alter existing functionality and ensures the job can only read repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
