### PR TITLE
ci(permissions): minimize GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   KUBE_VERSION: "1.33.4"
   SECRET_DOMAIN: "example.com"


### PR DESCRIPTION
- Impacted: .github/workflows/flux-local.yaml, .github/workflows/kubeconform.yml
- Change: Add explicit workflow-level permissions with least-privilege defaults (). Keep job-level  where needed (flux-local diff comment).
- Rationale: Ensure minimal token scope per GitHub security best practices; remove implicit defaults.
- Validation: Workflows still run; kubeconform and flux-local checkout steps require only contents:read; diff job retains PR commenting ability.

Please review. After merge, token scope is explicit across workflows.