### PR TITLE
feat(security): add Falco runtime detection via Helm

### DIFF
--- a/SECURITY_FALCO.md
+++ b/SECURITY_FALCO.md
@@ -1,0 +1,42 @@
+# Falco Runtime Security
+
+Falco is a CNCF project that provides runtime threat detection for Kubernetes. It complements policy enforcement tools like OPA Gatekeeper by monitoring system calls and Kubernetes audit events to detect suspicious behavior at run time.
+
+## Deployment
+
+Falco is deployed via Flux using the official Helm chart:
+
+- Namespace: `security`
+- Manifests: `kubernetes/apps/security/falco`
+- Helm source: `HelmRepository` `falco` within `app/helmrelease.yaml`
+- Flux Kustomization: `kubernetes/apps/security/falco/ks.yaml`
+- Chart version: `6.2.5`
+- Driver: `modern_ebpf` (CO-RE eBPF) to avoid kernel modules and work with Talos-style locked-down kernels.
+
+## Validation
+
+1. Confirm DaemonSet and Pods:
+
+   ```sh
+   kubectl -n security get ds,pods
+   ```
+
+2. Inspect recent events:
+
+   ```sh
+   kubectl -n security logs -l app.kubernetes.io/name=falco --tail=200
+   ```
+
+3. Optional safe trigger (non-disruptive):
+
+   ```sh
+   kubectl run -n default falco-test --rm -it --image=busybox -- sh -c 'cat /etc/shadow' || true
+   ```
+
+   This reads a sensitive file, generating a low-severity Falco alert.
+
+## Tuning
+
+- Modify `kubernetes/apps/security/falco/app/helm/values.yaml` to adjust resources, tolerations, or Falco rules.
+- Custom rules can be added via `falco.rules` entries or by mounting additional rule files (see chart docs).
+- Falco logs to stdout by default; integrate with existing logging stacks by updating Helm values if desired.

--- a/kubernetes/apps/security/falco/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/security/falco/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/security/falco/app/helm/values.yaml
+++ b/kubernetes/apps/security/falco/app/helm/values.yaml
@@ -1,0 +1,24 @@
+---
+driver:
+  enabled: true
+  kind: modern_ebpf
+  loader:
+    enabled: false
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: CriticalAddonsOnly
+    operator: Exists
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi

--- a/kubernetes/apps/security/falco/app/helmrelease.yaml
+++ b/kubernetes/apps/security/falco/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: falco
+  namespace: security # Required for Renovate lookups
+spec:
+  interval: 1h
+  url: https://falcosecurity.github.io/charts
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: falco
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: falco
+      version: 6.2.5
+      sourceRef:
+        kind: HelmRepository
+        name: falco
+        namespace: security
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: falco-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/security/falco/app/kustomization.yaml
+++ b/kubernetes/apps/security/falco/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: falco-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/security/falco/ks.yaml
+++ b/kubernetes/apps/security/falco/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app falco
+  namespace: &namespace security
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/security/falco/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+components:
+  - ../../components/common
+resources:
+  - ./falco/ks.yaml


### PR DESCRIPTION
## Summary
- add security namespace and Flux wiring
- deploy Falco DaemonSet via official Helm chart
- document runtime threat detection setup and validation steps

## Testing
- `bash scripts/validate.sh` *(fails: Missing required deps: kustomize kubeconform yq)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f6d67cac83339981f4e58cde4aae