### PR TITLE
feat(security): enable Falcosidekick UI via Tailscale

### DIFF
--- a/SECURITY_FALCO.md
+++ b/SECURITY_FALCO.md
@@ -13,6 +13,19 @@ Falco is deployed via Flux using the official Helm chart:
 - Chart version: `6.2.5`
 - Driver: `modern_ebpf` (CO-RE eBPF) to avoid kernel modules and work with Talos-style locked-down kernels.
 
+## Falcosidekick & Web UI
+
+Falcosidekick forwards Falco events and provides a simple UI. It is enabled via the Falco HelmRelease values at `kubernetes/apps/security/falco/app/helm/values.yaml`. The UI is exposed through Tailscale ingress at `https://falco-ui`.
+
+Quick checks:
+
+```sh
+kubectl -n security get deploy,svc
+kubectl -n security logs deploy/falco-falcosidekick --tail=100
+```
+
+Falco is automatically wired to Falcosidekick by the chart; no manual HTTP output configuration is required.
+
 ## Validation
 
 1. Confirm DaemonSet and Pods:

--- a/kubernetes/apps/security/falco/app/helm/values.yaml
+++ b/kubernetes/apps/security/falco/app/helm/values.yaml
@@ -22,3 +22,18 @@ resources:
   limits:
     cpu: 200m
     memory: 512Mi
+
+falcosidekick:
+  enabled: true
+  webui:
+    enabled: true
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: true
+      ingressClassName: tailscale
+      annotations: {}
+      hosts:
+        - host: falco-ui
+          paths:
+            - path: /


### PR DESCRIPTION
## Summary
- enable Falcosidekick and expose its web UI via Tailscale ingress
- document Falcosidekick access and validation steps

## Testing
- `bash scripts/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c310e920bc8333a5d88688de0517b2