### PR TITLE
ci(github): drop flux diff job

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -43,76 +43,9 @@ jobs:
         with:
           args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
 
-  diff:
-    name: Flux Local Diff
-    needs: pre-job
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    strategy:
-      matrix:
-        resources: ["helmrelease", "kustomization"]
-      max-parallel: 4
-      fail-fast: false
-    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
-    steps:
-      - name: Checkout Pull Request Branch
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          path: pull
-
-      - name: Checkout Default Branch
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: "${{ github.event.repository.default_branch }}"
-          path: default
-
-      - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v7.9.0
-        with:
-          args: >-
-            diff ${{ matrix.resources }}
-            --unified 6
-            --path /github/workspace/pull/kubernetes/flux/cluster
-            --path-orig /github/workspace/default/kubernetes/flux/cluster
-            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart"
-            --limit-bytes 10000
-            --all-namespaces
-            --sources "flux-system"
-            --output-file diff.patch
-
-      - name: Generate Diff
-        id: diff
-        run: |
-          cat diff.patch;
-          {
-              echo 'diff<<EOF'
-              cat diff.patch
-              echo EOF
-          } >> "$GITHUB_OUTPUT";
-          {
-              echo "### Diff"
-              echo '```diff'
-              cat diff.patch
-              echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Add Comment
-        if: ${{ steps.diff.outputs.diff != '' }}
-        continue-on-error: true
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
-        with:
-          message-id: "${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resources }}"
-          message-failure: Diff was not successful
-          message: |
-            ```diff
-            ${{ steps.diff.outputs.diff }}
-            ```
-
   flux-local-status:
     name: Flux Local Success
-    needs: ["test", "diff"]
+    needs: ["test"]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:


### PR DESCRIPTION
## Summary
- remove Flux diff step from workflow
- rely solely on flux-local tests

## Testing
- `mise trust && mise install` *(fails: failed to install aqua:helm/helm@3.19.0: client error (Connect))*
- `bash scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5228729cc83338ed33b0f43db0324