### PR TITLE
feat(ai/graphiti): deploy Graphiti MCP with Neo4j backend and Tailscale ingress

### DIFF
--- a/kubernetes/apps/ai/graphiti/README.md
+++ b/kubernetes/apps/ai/graphiti/README.md
@@ -1,0 +1,12 @@
+# Graphiti MCP Server
+
+Deploys the Graphiti Model Context Protocol (MCP) server backed by Neo4j. The service exposes an SSE endpoint at `/sse` for real-time responses.
+
+## Access
+
+- **Ingress**: `https://graphiti.${SECRET_TAILNET}`
+- **SSE Endpoint**: `https://graphiti.${SECRET_TAILNET}/sse`
+
+## Client Configuration
+
+Configure MCP clients to connect to the SSE endpoint and authenticate using the `OPENAI_API_KEY` stored in the `graphiti-env` secret.

--- a/kubernetes/apps/ai/graphiti/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/ai/graphiti/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/ai/graphiti/app/helm/values.yaml
+++ b/kubernetes/apps/ai/graphiti/app/helm/values.yaml
@@ -1,0 +1,71 @@
+controllers:
+  graphiti:
+    containers:
+      app:
+        env:
+          - name: MODEL_NAME
+            value: gpt-4o-mini
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: graphiti-env
+                key: OPENAI_API_KEY
+          - name: NEO4J_URI
+            value: bolt://neo4j-graphiti-neo4j:7687
+          - name: NEO4J_USER
+            value: neo4j
+          - name: NEO4J_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: graphiti-env
+                key: NEO4J_PASSWORD
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /sse
+                port: 8000
+              initialDelaySeconds: 0
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /sse
+                port: 8000
+              initialDelaySeconds: 0
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+service:
+  app:
+    ports:
+      http:
+        port: 8000
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: graphiti.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - graphiti.${SECRET_TAILNET}

--- a/kubernetes/apps/ai/graphiti/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/graphiti/app/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: graphiti
+  namespace: ai # Required for Renovate lookups
+spec:
+  interval: 1h
+  url: https://kiberonlabs.github.io/helm-charts
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app graphiti
+  namespace: ai
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: graphiti-mcp
+      version: 0.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: graphiti
+        namespace: ai
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: graphiti-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/graphiti/app/kustomization.yaml
+++ b/kubernetes/apps/ai/graphiti/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml
+configMapGenerator:
+  - name: graphiti-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/graphiti/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/graphiti/app/secret.sops.yaml
@@ -1,0 +1,27 @@
+# NOTE: This secret needs to be encrypted with SOPS before deployment
+# Run: sops -e -i kubernetes/apps/ai/graphiti/app/secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: graphiti-env
+  namespace: ai
+type: Opaque
+stringData:
+  OPENAI_API_KEY: ENC[AES256_GCM,data:xdoC1bSuCrs=,iv:ljZkBtjf5VAIZyczcQEQqlCvDMaDKKZoEdNx28Aob4Q=,tag:Olbh8Cv+n35f7U41EkMcEg==,type:str]
+  NEO4J_PASSWORD: ENC[AES256_GCM,data:EwUvW0fbrbg=,iv:0mmSSQPj9kLpdXHpQxbU4IOgcRMP4Of9X6AHV5cHMYE=,tag:Wf5DiLle42t1jdEWzhOikg==,type:str]
+sops:
+  age:
+    - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTNlJTWUc3Uk9SMHJyQ0JX
+        MDhhdWNVV1FORnRxNWdxVDI0N3V2V2pnK2xFCmVkYkNwc2dvL2l4Q2dtZTZDRmw2
+        NmgzajBKTGU3czk4cmVKeGx2cUh0MlUKLS0tIE1hRy9MVDVsRGZuRTZocFFYK2p4
+        UHE2czV3SEFZU0REbUJCbmE2ZHQ1YXcK4ReWbVt4tXp7rfZyUpFau5xEA5jwg2mL
+        fmyQQ5+rlSFSqRHoHBHdZdIf6zTd0XGjadJ3HKa1IEReNxnfWOYscQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-09-13T19:51:22Z"
+  mac: ENC[AES256_GCM,data:lZEYAidyVXS5y7h1KY5PvO0vQhSaSPLDT+RfQSVxAKz+WH2FhvxWLeL/uo4KDU0lOBaaxfJplbTS+1cLbONTPObZg6tavDv2UErpArxxDe4aWPi8QMiwaymHiqLpp/Z+DBzORSRbJ315gOjwSKwzh2sQYhx5afmZFENqHZyRHDc=,iv:K1kGrWDb+nRCmozipoxP/QcBEALVMEmDMLR/yQ4dCl0=,tag:33LXzAcWsrkyPt8xFYFPyw==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/ai/graphiti/ks.yaml
+++ b/kubernetes/apps/ai/graphiti/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app graphiti
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: neo4j-graphiti
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/ai/graphiti/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -7,3 +7,5 @@ components:
   - ../../components/common
 resources:
   - ./dify/ks.yaml
+  - ./neo4j-graphiti/ks.yaml
+  - ./graphiti/ks.yaml

--- a/kubernetes/apps/ai/neo4j-graphiti/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/ai/neo4j-graphiti/app/helm/values.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/app/helm/values.yaml
@@ -1,0 +1,17 @@
+neo4j:
+  name: neo4j
+  acceptLicenseAgreement: "yes"
+  existingPasswordSecret: graphiti-env
+  existingPasswordSecretKey: NEO4J_PASSWORD
+core:
+  standalone: true
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      cpu: 1
+      memory: 4Gi
+  persistentVolume:
+    storageClassName: longhorn
+    size: 10Gi

--- a/kubernetes/apps/ai/neo4j-graphiti/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/app/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: neo4j
+  namespace: ai # Required for Renovate lookups
+spec:
+  interval: 1h
+  url: https://helm.neo4j.com/neo4j
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app neo4j-graphiti
+  namespace: ai
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: neo4j
+      version: v2025.8.0-0
+      sourceRef:
+        kind: HelmRepository
+        name: neo4j
+        namespace: ai
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: neo4j-graphiti-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/neo4j-graphiti/app/kustomization.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml
+configMapGenerator:
+  - name: neo4j-graphiti-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/neo4j-graphiti/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/app/secret.sops.yaml
@@ -1,0 +1,27 @@
+# NOTE: This secret needs to be encrypted with SOPS before deployment
+# Run: sops -e -i kubernetes/apps/ai/neo4j-graphiti/app/secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: graphiti-env
+  namespace: ai
+type: Opaque
+stringData:
+  OPENAI_API_KEY: ENC[AES256_GCM,data:fprqFq/Zc1s=,iv:yzRHQ8veJOVMX3GTkcc8zqkb/S0sDXNSBG8A2fP59Cg=,tag:U0MLNgUAYpJchDRZtUhT8A==,type:str]
+  NEO4J_PASSWORD: ENC[AES256_GCM,data:eRA/BQqgNGg=,iv:Y/S8qangElnvT2v44jMwlasPLzkfwCpc/6+7nUsdbD8=,tag:XPVuEExwCcVuC7+FzcnEEQ==,type:str]
+sops:
+  age:
+    - recipient: age1ah5azswjpvcjylvh3w4mr0vzhrgh3dzjq7gh2jrxq5sw9789hquqt6kg6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1SzJ1bjhvMkRNUENwbjJE
+        cVJUSFhaTmljUXZ1eXlzYm5PMlQvRUZFSlhzClV5YTI5ZWhsWU1XcStJM3BFcUt6
+        UENIR2dKbkhicFNIdE42T2RwbjYyUmMKLS0tIGdsZkNVd1RUZytUM1hxSUVNa09R
+        MHVwTVp1TDAxRGsrTFFtclNiYTNxQW8KjNRKoTfSN6ccWe1ZL6z6mWm8ym6r33i2
+        lotZR/nYgllBgxmYWac4WbkfSZiFim9FnIJw3SZaV4pCvJKq8woXlQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-09-13T19:51:26Z"
+  mac: ENC[AES256_GCM,data:inF/Nl9ATCzMwcXRFZdC5rdM9l+UKN7A6CrfJaMhMKaW/OGjND1DN3Ut8kUPedCuuiy6w0TEMw1SIKqhmHM+T1bo8u06RoK/YzbwauGWu5kal986h7pfpZGIuCu+YecLbvqKbON1/+D80mbHv9lCdLvpCYfyJZk1tnmx/CJyIAI=,iv:VBD9ApUHHbE703bD8zVVCKGiOhokdKhlhn13E38r/w4=,tag:1aVmaTFGRYCAoPmVWEo/Bg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/ai/neo4j-graphiti/ks.yaml
+++ b/kubernetes/apps/ai/neo4j-graphiti/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app neo4j-graphiti
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/ai/neo4j-graphiti/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- add Neo4j single-node database for Graphiti with Longhorn storage
- deploy Graphiti MCP server with Tailscale ingress and Neo4j backend
- document SSE endpoint for clients
- set Neo4j chart name to satisfy Helm requirements

## Testing
- `mise install` *(fails: error sending request for url (https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz) tunnel error)*
- `bash scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca8257148333a3ec61d645516c24