### PR TITLE
Deploy Qdrant MCP Server with Helm Charts

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../components/common
 resources:
   - ./dify/ks.yaml
+  - ./qdrant/ks.yaml

--- a/kubernetes/apps/ai/qdrant/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/ai/qdrant/app/helm/mcp-values.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helm/mcp-values.yaml
@@ -1,0 +1,63 @@
+# Deploy Qdrant MCP server using bjw-s app-template
+controllers:
+  mcp:
+    strategy: RollingUpdate
+    replicas: 1
+    containers:
+      app:
+        image:
+          # Official GHCR image for Qdrant MCP server
+          repository: ghcr.io/qdrant/mcp-server-qdrant
+          tag: latest
+        env:
+          # FastMCP server settings
+          FASTMCP_HOST: 0.0.0.0
+          FASTMCP_PORT: "8000"
+          # Qdrant connection
+          QDRANT_URL: http://qdrant.ai.svc.cluster.local:6333
+          # QDRANT_API_KEY: ${QDRANT_API_KEY}
+          COLLECTION_NAME: mcp-memory
+        ports:
+          - name: http
+            containerPort: 8000
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+            port: http
+          readiness:
+            enabled: true
+            type: TCP
+            port: http
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+service:
+  app:
+    controller: mcp
+    ports:
+      http:
+        port: 8000
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: qdrant-mcp.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - qdrant-mcp.${SECRET_TAILNET}

--- a/kubernetes/apps/ai/qdrant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helm/values.yaml
@@ -1,0 +1,52 @@
+# Qdrant configuration tuned for the homelab cluster
+image:
+  repository: qdrant/qdrant
+  # appVersion is managed by the chart; override only if needed
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 6333
+
+ingress:
+  enabled: true
+  className: tailscale
+  annotations: {}
+  hosts:
+    - host: qdrant.${SECRET_TAILNET}
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: qdrant-tls
+      hosts:
+        - qdrant.${SECRET_TAILNET}
+
+persistence:
+  enabled: true
+  storageClass: longhorn
+  accessModes:
+    - ReadWriteOnce
+  size: 32Gi
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 2000m
+    memory: 4Gi
+
+# Configure API key auth (optional). If you enable, ensure clients send Api-Key header.
+# You can also set via env QDRANT__SERVICE__API_KEY through extraEnv.
+config:
+  service:
+    # api_key: ${QDRANT_API_KEY}
+    enable_tls: false
+
+# Extra environment for Qdrant container
+extraEnv: []
+
+# ServiceMonitor for scraping metrics (if chart supports)
+serviceMonitor:
+  enabled: false

--- a/kubernetes/apps/ai/qdrant/app/helmrelease-mcp.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helmrelease-mcp.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: qdrant-mcp
+  namespace: ai
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  dependsOn:
+    - name: qdrant
+      namespace: ai
+  valuesFrom:
+    - kind: ConfigMap
+      name: mcp-qdrant-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/qdrant/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: qdrant
+  namespace: ai
+spec:
+  interval: 1h
+  url: https://qdrant.github.io/qdrant-helm
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app qdrant
+  namespace: ai
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: qdrant
+      # Pin chart for reproducibility; Renovate will keep this updated
+      version: 1.14.0
+      sourceRef:
+        kind: HelmRepository
+        name: qdrant
+        namespace: ai
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: qdrant-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/qdrant/app/kustomization.yaml
+++ b/kubernetes/apps/ai/qdrant/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./helmrelease-mcp.yaml
+
+configMapGenerator:
+  - name: qdrant-values
+    files:
+      - values.yaml=./helm/values.yaml
+  - name: mcp-qdrant-values
+    files:
+      - values.yaml=./helm/mcp-values.yaml
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/qdrant/ks.yaml
+++ b/kubernetes/apps/ai/qdrant/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app qdrant
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/ai/qdrant/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
This pull request implements the deployment of the Qdrant application along with its MCP server using official Helm charts in the 'ai' namespace. The changes include the addition of necessary configuration files for Helm releases, values for the application, and a Kustomization file to integrate with FluxCD. The configuration adheres to the repository conventions established in similar deployments (like Dify and Coder), facilitating easy management and scalability of the Qdrant services.

---

> This pull request was co-created with Cosine Genie

Original Task: [homelab/ne7mqekha9aq](https://cosine.sh/oz3q8e0atknt/homelab/task/ne7mqekha9aq)
Author: sajudia
