### PR TITLE
chore(renovate): assign prs to owner

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -12,6 +12,9 @@
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',
+  assignees: [
+    'yamshy',
+  ],
   ignorePaths: [
     '**/*.sops.*',
   ],


### PR DESCRIPTION
## Summary
- assign Renovate pull requests to the repository owner by default

## Testing
- bash scripts/validate.sh *(fails: Missing required deps: kustomize kubeconform yq)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9496c25083339588e24811d7853b