### PR TITLE
chore(renovate): automerge patch updates after checks

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,7 +4,6 @@
     'config:recommended',
     'docker:enableMajor',
     'helpers:pinGitHubActionDigests',
-    ':automergeBranch',
     ':dependencyDashboard',
     ':disableRateLimiting',
     ':semanticCommits',
@@ -229,6 +228,13 @@
     {
       matchUpdateTypes: [
         'patch',
+      ],
+      automerge: true,
+      automergeType: 'pr',
+      requiredStatusChecks: [
+        'Flux Local / Flux Local Success',
+        'kubeconform-validate / validate',
+        'trufflehog-secrets-scan / TruffleHog OSS Secret Scan',
       ],
       labels: [
         'type/patch',


### PR DESCRIPTION
## Summary
- remove the branch-level automerge preset so Renovate opens PRs for dependency updates
- configure patch updates to automerge after the Flux Local, kubeconform, and trufflehog checks succeed

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd9679a6748333bd42c28a1ddfd396