### PR TITLE
chore(renovate): auto-merge minor and patch updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -41,12 +41,17 @@
   },
   packageRules: [
     {
-      description: 'Auto-merge minor and patch updates',
+      description: 'Auto-merge minor updates',
       matchUpdateTypes: [
         'minor',
-        'patch',
       ],
       automerge: true,
+      automergeType: 'pr',
+      requiredStatusChecks: [
+        'Flux Local / Flux Local Success',
+        'kubeconform-validate / validate',
+        'trufflehog-secrets-scan / TruffleHog OSS Secret Scan',
+      ],
     },
     {
       description: 'Cert-Manager Group',

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -11,9 +11,6 @@
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',
-  assignees: [
-    'yamshy',
-  ],
   ignorePaths: [
     '**/*.sops.*',
   ],
@@ -43,6 +40,14 @@
     ],
   },
   packageRules: [
+    {
+      description: 'Auto-merge minor and patch updates',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      automerge: true,
+    },
     {
       description: 'Cert-Manager Group',
       groupName: 'Cert-Manager',


### PR DESCRIPTION
## Summary
- enable Renovate to automerge minor and patch updates via a shared package rule
- remove the default Renovate assignee so PRs are no longer auto-assigned

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd9d59f2f08333bc087506574041c3