### PR TITLE
feat(ai): deploy resume assistant

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../components/common
 resources:
   - ./dify/ks.yaml
+  - ./resume-assistant/ks.yaml

--- a/kubernetes/apps/ai/resume-assistant/README.md
+++ b/kubernetes/apps/ai/resume-assistant/README.md
@@ -1,0 +1,73 @@
+# Resume Assistant (Kubernetes App)
+
+Concise documentation for deploying the Resume Assistant service via Flux and the bjw-s app-template chart.
+
+## Quick links
+
+- Namespace: `ai`
+- Flux Kustomization: `kubernetes/apps/ai/resume-assistant/ks.yaml`
+- HelmRelease: `kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml`
+- Chart values: `kubernetes/apps/ai/resume-assistant/app/helm/values.yaml`
+- Infisical secret: `kubernetes/apps/ai/resume-assistant/app/secrets.infisical.yaml`
+
+## Overview
+
+This deployment exposes the [`ghcr.io/yamshy/resume-assistant`](https://github.com/yamshy/resume-assistant) container (tag `1.0.1`)
+behind Flux. Runtime configuration is supplied exclusively through the rendered ConfigMap that feeds the HelmRelease.
+
+## Workload
+
+- Chart: `app-template` via the shared `app-template` OCIRepository
+- Controller: single `resume-assistant` deployment managed by the chart
+- Resources (from values): requests `100m` CPU / `256Mi`, limits `500m` CPU / `512Mi`
+- Persistence: ephemeral `emptyDir` volume mounted at `/data` for the knowledge store file
+
+## Networking and exposure
+
+- Service: ClusterIP on port `80` targeting the container's `8000`
+- Ingress: Tailscale ingress class
+  - Host: `resume-assistant.${SECRET_TAILNET}`
+  - TLS: secret `resume-assistant-tls`
+
+## Secrets & substitutions
+
+- Application API access comes from the Infisical-managed secret `resume-assistant-env`
+  (`OPENAI_API_KEY` key).
+- Flux post-build substitution pulls `${SECRET_TAILNET}` from the same Infisical-managed secret so the Tailscale hostname renders correctly.
+
+## Dependencies
+
+- Flux (Helm & Kustomize controllers)
+- Infisical Secrets Operator (manages `resume-assistant-env`)
+- Tailscale operator for the `tailscale` IngressClass
+
+## Operations
+
+- Trigger a reconcile:
+
+  ```sh
+  flux reconcile kustomization resume-assistant -n ai
+  ```
+
+- Inspect workloads:
+
+  ```sh
+  kubectl -n ai get helmrelease,deploy,svc,ing,pod
+  ```
+
+- Edit chart values and re-run validation:
+
+  ```sh
+  $EDITOR kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+  bash scripts/validate.sh
+  ```
+
+## File map
+
+- Flux Kustomization: `kubernetes/apps/ai/resume-assistant/ks.yaml`
+- App manifests: `kubernetes/apps/ai/resume-assistant/app/`
+  - `helmrelease.yaml` – HelmRelease definition referencing the shared `app-template` chart
+  - `helm/values.yaml` – chart values rendered via ConfigMapGenerator
+  - `helm/kustomizeconfig.yaml` – rewrites `valuesFrom` ConfigMap names
+  - `kustomization.yaml` – wires the HelmRelease, values ConfigMap, and Infisical secret
+  - `secrets.infisical.yaml` – InfisicalSecret fetching `OPENAI_API_KEY`

--- a/kubernetes/apps/ai/resume-assistant/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -13,8 +13,9 @@ controllers:
                 name: resume-assistant-env
                 key: OPENAI_API_KEY
         ports:
-          http:
+          - name: http
             containerPort: 8000
+            protocol: HTTP
         probes:
           liveness:
             enabled: true
@@ -55,8 +56,9 @@ controllers:
 service:
   app:
     ports:
-      http:
+      - name: http
         port: 80
+        protocol: TCP
         targetPort: http
 
 ingress:

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -56,7 +56,7 @@ controllers:
 service:
   app:
     ports:
-      - name: http
+      http:
         port: 80
         protocol: TCP
         targetPort: http

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -1,0 +1,78 @@
+controllers:
+  resume-assistant:
+    strategy: RollingUpdate
+    containers:
+      app:
+        image:
+          repository: ghcr.io/yamshy/resume-assistant
+          tag: 1.0.1
+        env:
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: resume-assistant-env
+                key: OPENAI_API_KEY
+        ports:
+          http:
+            containerPort: 8000
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: http
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: http
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
+
+service:
+  app:
+    controller: resume-assistant
+    ports:
+      http:
+        port: 80
+        targetPort: http
+
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: resume-assistant.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - secretName: resume-assistant-tls
+        hosts:
+          - resume-assistant.${SECRET_TAILNET}
+
+persistence:
+  data:
+    enabled: true
+    type: emptyDir
+    globalMounts:
+      - path: /data

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -38,16 +38,22 @@ controllers:
               periodSeconds: 10
               timeoutSeconds: 1
               failureThreshold: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+              - "ALL"
         resources:
           requests:
             cpu: 100m
             memory: 256Mi
           limits:
+            cpu: 500m
             memory: 512Mi
 
 service:
   app:
-    controller: resume-assistant
     ports:
       http:
         port: 80
@@ -57,6 +63,7 @@ ingress:
   app:
     enabled: true
     className: tailscale
+    annotations: {}
     hosts:
       - host: resume-assistant.${SECRET_TAILNET}
         paths:

--- a/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  dependsOn:
+    - name: tailscale-operator
+      namespace: network
   valuesFrom:
     - kind: ConfigMap
       name: resume-assistant-values

--- a/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app resume-assistant
+  namespace: ai
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: resume-assistant-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secrets.infisical.yaml
+
+configMapGenerator:
+  - name: resume-assistant-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
@@ -11,5 +11,8 @@ configMapGenerator:
     files:
       - values.yaml=./helm/values.yaml
 
+generatorOptions:
+  disableNameSuffixHash: false
+
 configurations:
   - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/resume-assistant/app/secrets.infisical.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/secrets.infisical.yaml
@@ -1,0 +1,24 @@
+# InfisicalSecret for resume-assistant secrets in ai namespace
+# Reference: https://infisical.com/docs/integrations/platforms/kubernetes/infisical-secret-crd
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: resume-assistant-env
+  namespace: ai
+spec:
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: "homelab-0r-b1"
+        envSlug: "prod"
+        secretsPath: "/"
+        recursive: true
+      credentialsRef:
+        secretName: "universal-auth-credentials"
+        secretNamespace: "kube-system"  # Infrastructure credentials
+  managedSecretReference:
+    secretName: "resume-assistant-env"  # Name of resulting Kubernetes secret
+    secretNamespace: "ai"
+    creationPolicy: "Orphan"  # Keep secret if InfisicalSecret is deleted

--- a/kubernetes/apps/ai/resume-assistant/ks.yaml
+++ b/kubernetes/apps/ai/resume-assistant/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app resume-assistant
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: infisical-secrets-operator
+      namespace: infisical-system
+  interval: 1h
+  path: ./kubernetes/apps/ai/resume-assistant/app
+  postBuild:
+    substituteFrom:
+      - name: resume-assistant-env
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- add Flux Kustomization and HelmRelease for the resume-assistant service in the `ai` namespace
- configure app-template values with Tailscale ingress, service exposure, and OPENAI_API_KEY secret wiring
- provision an InfisicalSecret and config map wiring for chart values

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68cfac5cdad88333ba8c3f69fa0d9d2b