### PR TITLE
chore(scripts): ensure envsubst dependency

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -7,7 +7,7 @@ source "$(dirname "${0}")/lib/common.sh"
 : "${SECRET_DOMAIN:=example.com}"
 export SECRET_DOMAIN
 
-check_cli git kustomize kubeconform yq
+check_cli git kustomize kubeconform envsubst yq
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "${ROOT_DIR}"


### PR DESCRIPTION
## Summary
- add envsubst to the dependency check in scripts/validate.sh so validation stops early when it is unavailable

## Testing
- bash scripts/validate.sh # (with envsubst temporarily removed from PATH, exits early as expected)
- bash scripts/validate.sh


------
https://chatgpt.com/codex/tasks/task_e_68d0325ddfbc833396405fa4dedf60e4