### PR TITLE
ci: add shell and talos linters

### DIFF
--- a/.github/workflows/shell-and-talos-lint.yml
+++ b/.github/workflows/shell-and-talos-lint.yml
@@ -1,4 +1,6 @@
 name: Shell and Talos lint
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/shell-and-talos-lint.yml
+++ b/.github/workflows/shell-and-talos-lint.yml
@@ -1,0 +1,42 @@
+name: Shell and Talos lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files 'scripts/**/*.sh')
+          if [ "${#files[@]}" -eq 0 ]; then
+              echo "No shell scripts to lint."
+              exit 0
+          fi
+          shellcheck "${files[@]}"
+
+  talhelper-validate:
+    name: Talhelper validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install talhelper
+        run: |
+          set -euo pipefail
+          curl -sSL https://github.com/budimanjojo/talhelper/releases/latest/download/talhelper_linux_amd64.tar.gz -o /tmp/talhelper.tar.gz
+          tar -xzf /tmp/talhelper.tar.gz -C /tmp talhelper
+          sudo install -m 0755 /tmp/talhelper /usr/local/bin/talhelper
+      - name: Validate Talos configuration
+        run: talhelper validate talconfig talos/talconfig.yaml --env-file talos/talenv.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ bash scripts/validate.sh
 ```
 
 - If validation fails, fix the issues before proceeding.
+- CI also runs targeted linters to catch regressions early. Re-run them locally when touching the corresponding areas:
+
+    - Shell scripts: install [`shellcheck`](https://www.shellcheck.net/) (e.g., `sudo apt-get install shellcheck` or `brew install shellcheck`) and execute `shellcheck $(git ls-files 'scripts/**/*.sh')`.
+    - Talos configuration: install [`talhelper`](https://github.com/budimanjojo/talhelper) (e.g., `mise install talhelper` or download the latest release tarball) and run `talhelper validate talconfig talos/talconfig.yaml --env-file talos/talenv.yaml`.
 
 ### Helm chart source placement
 - Co-locate chart sources with the app’s HelmRelease in the same file (`app/helmrelease.yaml`) as a second YAML document (`---`) when adding new apps.


### PR DESCRIPTION
## Summary
- add a pull-request workflow that runs ShellCheck across scripts and validates the Talos config with talhelper
- document how contributors can run the new shell and Talos checks locally

## Testing
- `bash -lc 'set -euo pipefail; mapfile -t files < <(git ls-files "scripts/**/*.sh"); if [ "${#files[@]}" -eq 0 ]; then echo "No files"; else shellcheck "${files[@]}"; fi'`
- `/tmp/talhelper validate talconfig talos/talconfig.yaml --env-file talos/talenv.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68d0327fb42c83339bcfb66338593c6b