### PR TITLE
feat(resume-assistant): back data with longhorn

### DIFF
--- a/kubernetes/apps/ai/resume-assistant/README.md
+++ b/kubernetes/apps/ai/resume-assistant/README.md
@@ -20,7 +20,7 @@ behind Flux. Runtime configuration is supplied exclusively through the rendered 
 - Chart: `app-template` via the shared `app-template` OCIRepository
 - Controller: single `resume-assistant` deployment managed by the chart
 - Resources (from values): requests `100m` CPU / `256Mi`, limits `500m` CPU / `512Mi`
-- Persistence: ephemeral `emptyDir` volume mounted at `/data` for the knowledge store file
+- Persistence: 5Gi `longhorn`-backed PVC mounted at `/data` for the knowledge store file
 
 ## Networking and exposure
 

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -84,8 +84,7 @@ persistence:
     enabled: true
     type: persistentVolumeClaim
     storageClass: longhorn
-    accessModes:
-      - ReadWriteOnce
+    accessMode: ReadWriteOnce
     size: 5Gi
     globalMounts:
       - path: /data

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -82,9 +82,10 @@ ingress:
 persistence:
   data:
     enabled: true
-    type: pvc
+    type: persistentVolumeClaim
     storageClass: longhorn
-    accessMode: ReadWriteOnce
+    accessModes:
+      - ReadWriteOnce
     size: 5Gi
     globalMounts:
       - path: /data

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -82,6 +82,9 @@ ingress:
 persistence:
   data:
     enabled: true
-    type: emptyDir
+    type: pvc
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 5Gi
     globalMounts:
       - path: /data


### PR DESCRIPTION
## Summary
- configure the resume-assistant chart values to mount /data from a Longhorn-backed PVC instead of an emptyDir
- document the persistent volume details in the app README

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68d05a0e63b88333bbb89bb450cfd3e0