### PR TITLE
docs(repo): require flux-local pre-commit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,12 @@
 - Secrets: commit only `*.sops.yaml`; never plaintext. SOPS config in `.sops.yaml`.
 
 ## Testing Guidelines
-- Local: run `bash scripts/validate.sh`; ensure zero kubeconform errors.
+- Local: run `bash scripts/validate.sh` and the Flux Local test suite before committing; ensure zero kubeconform errors and no unexpected diffs.
+  - Mirror CI locally with:
+    ```bash
+    docker run --rm -v "${PWD}:/workspace" ghcr.io/allenporter/flux-local:v7.10.0 \
+      test --enable-helm --all-namespaces --path /workspace/kubernetes/flux/cluster -v
+    ```
 - Optional sanity: `kustomize build <overlay> | yq e 'del(.sops)' -` to inspect rendered YAML.
 - CI: PRs run strict kubeconform and flux‑local diff/tests; fix all diffs/violations.
 


### PR DESCRIPTION
## Summary
- update the testing guidelines in `AGENTS.md` to require running the Flux Local test suite alongside the existing validation script before committing
- document the exact docker command to mirror the CI flux-local run when testing locally

## Testing
- `bash scripts/validate.sh` *(fails: missing required deps `kustomize kubeconform yq` in container)*
- `docker run --rm -v "${PWD}:/workspace" ghcr.io/allenporter/flux-local:v7.10.0 test --enable-helm --all-namespaces --path /workspace/kubernetes/flux/cluster -v` *(fails: docker CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0609af7708333b88f0c3c56b623bf