### PR TITLE
feat(apps): add nextflow demo guardrails

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./kube-system
   - ./monitoring
   - ./network
+  - ./nextflow-demo
   - ./portfolio
   - ./security
   - ./storage

--- a/kubernetes/apps/nextflow-demo/guardrails/ciliumnetworkpolicy-allow-registries.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/ciliumnetworkpolicy-allow-registries.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/cilium/v1.18.1/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicy.yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-registries-egress
+  namespace: nextflow-demo
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: auth.docker.io
+        - matchName: docker.io
+        - matchName: ghcr.io
+        - matchName: public.ecr.aws
+        - matchName: quay.io
+        - matchName: registry-1.docker.io
+        - matchName: registry.k8s.io
+        - matchName: us.gcr.io
+        - matchName: gcr.io
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/kubernetes/apps/nextflow-demo/guardrails/configmap-opa-allowlist.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/configmap-opa-allowlist.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextflow-demo-allowed-images
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: nextflow-demo-allowed-images
+    app.kubernetes.io/part-of: nextflow-demo
+    opa.home.arpa/policy: allowed-images
+  annotations:
+    opa.home.arpa/description: Optional allow-list consumed by Gatekeeper/OPA policies when present.
+data:
+  repositories.yaml: |
+    allowed:
+      - ghcr.io/nextflow/*
+      - ghcr.io/datasets/*
+      - public.ecr.aws/*
+      - quay.io/biocontainers/*
+      - docker.io/library/*

--- a/kubernetes/apps/nextflow-demo/guardrails/ks.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app guardrails
+  namespace: &namespace nextflow-demo
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      app.kubernetes.io/part-of: nextflow-demo
+  interval: 1h
+  path: ./kubernetes/apps/nextflow-demo/guardrails
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/nextflow-demo/guardrails/kustomization.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./resourcequota.yaml
+  - ./limitrange.yaml
+  - ./networkpolicy-default-deny-egress.yaml
+  - ./networkpolicy-allow-dns.yaml
+  - ./networkpolicy-allow-minio.yaml
+  - ./ciliumnetworkpolicy-allow-registries.yaml
+  - ./configmap-opa-allowlist.yaml

--- a/kubernetes/apps/nextflow-demo/guardrails/limitrange.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/limitrange.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: compute-defaults
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: compute-defaults
+    app.kubernetes.io/part-of: nextflow-demo
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 500m
+        memory: 1Gi
+        ephemeral-storage: 4Gi
+      default:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 8Gi
+      max:
+        cpu: "4"
+        memory: 8Gi
+        ephemeral-storage: 16Gi
+      min:
+        cpu: 100m
+        memory: 256Mi
+        ephemeral-storage: 1Gi
+    - type: PersistentVolumeClaim
+      min:
+        storage: 1Gi
+      max:
+        storage: 200Gi

--- a/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-allow-dns.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-allow-dns.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: allow-dns
+    app.kubernetes.io/part-of: nextflow-demo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-allow-minio.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-allow-minio.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-minio
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: allow-minio
+    app.kubernetes.io/part-of: nextflow-demo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: storage
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: minio
+      ports:
+        - protocol: TCP
+          port: 9000
+        - protocol: TCP
+          port: 9443

--- a/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-default-deny-egress.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/networkpolicy-default-deny-egress.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: default-deny-egress
+    app.kubernetes.io/part-of: nextflow-demo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress

--- a/kubernetes/apps/nextflow-demo/guardrails/rbac.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/rbac.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nextflow-runner
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: nextflow-runner
+    app.kubernetes.io/part-of: nextflow-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nextflow-runner
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: nextflow-runner
+    app.kubernetes.io/part-of: nextflow-demo
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - secrets
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nextflow-runner
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: nextflow-runner
+    app.kubernetes.io/part-of: nextflow-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nextflow-runner
+subjects:
+  - kind: ServiceAccount
+    name: nextflow-runner
+    namespace: nextflow-demo

--- a/kubernetes/apps/nextflow-demo/guardrails/resourcequota.yaml
+++ b/kubernetes/apps/nextflow-demo/guardrails/resourcequota.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-quotas
+  namespace: nextflow-demo
+  labels:
+    app.kubernetes.io/name: compute-quotas
+    app.kubernetes.io/part-of: nextflow-demo
+spec:
+  hard:
+    pods: "50"
+    requests.cpu: "8"
+    requests.memory: 32Gi
+    requests.ephemeral-storage: 200Gi
+    limits.cpu: "16"
+    limits.memory: 64Gi
+    limits.ephemeral-storage: 400Gi
+    persistentvolumeclaims: "10"

--- a/kubernetes/apps/nextflow-demo/kustomization.yaml
+++ b/kubernetes/apps/nextflow-demo/kustomization.yaml
@@ -15,7 +15,7 @@ patches:
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: not-used
+        name: nextflow-demo
         labels:
           pod-security.kubernetes.io/audit: restricted
           pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/nextflow-demo/kustomization.yaml
+++ b/kubernetes/apps/nextflow-demo/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nextflow-demo
+components:
+  - ../../components/common
+resources:
+  - ./guardrails/ks.yaml
+patches:
+  - target:
+      kind: Namespace
+      name: not-used
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: not-used
+        labels:
+          pod-security.kubernetes.io/audit: restricted
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/enforce: restricted
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/warn: restricted
+          pod-security.kubernetes.io/warn-version: latest


### PR DESCRIPTION
## Summary
- add the nextflow-demo namespace with restricted pod-security labels
- bootstrap a guardrails Flux Kustomization that wires RBAC, quotas/limits, and network controls
- provide an optional OPA image allow-list configmap for future policy enforcement

## Impacted Paths
- kubernetes/apps/kustomization.yaml
- kubernetes/apps/nextflow-demo/**

## Testing
- bash scripts/validate.sh


------
https://chatgpt.com/codex/tasks/task_e_68d188cef31c83338fa3f606a12f8504