### PR TITLE
feat(ai): enable resume-assistant image automation

### DIFF
--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/yamshy/resume-assistant
-          tag: 1.4.2
+          tag: 1.4.2 # {"$imagepolicy": "ai:resume-assistant-image-policy:tag"}
         env:
           - name: OPENAI_API_KEY
             valueFrom:

--- a/kubernetes/apps/ai/resume-assistant/app/imagepolicy.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/imagepolicy.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/imagepolicy-image-v1beta2.json
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: resume-assistant-image-policy
+spec:
+  imageRepositoryRef:
+    name: resume-assistant-image
+  policy:
+    semver:
+      range: '1.x'

--- a/kubernetes/apps/ai/resume-assistant/app/imagerepository.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/imagerepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/imagerepository-source-v1beta2.json
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: resume-assistant-image
+spec:
+  image: ghcr.io/yamshy/resume-assistant
+  interval: 5m

--- a/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./imagerepository.yaml
+  - ./imagepolicy.yaml
 
 configMapGenerator:
   - name: resume-assistant-values


### PR DESCRIPTION
## Summary
- add Flux ImageRepository and ImagePolicy resources for resume-assistant
- annotate the Helm values image tag so Flux automation can update it
- include the automation resources in the app kustomization

## Testing
- bash scripts/validate.sh


------
https://chatgpt.com/codex/tasks/task_e_68d2f52496bc8333b5dd00523aa9005f