### PR TITLE
fix(flux): scope controller concurrency patches

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helm/values.yaml
@@ -25,7 +25,7 @@ instance:
       app.kubernetes.io/name: flux
   kustomize:
     patches:
-      - # Increase the number of workers
+      - # Increase the number of workers for Git and Helm controllers
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
@@ -35,7 +35,7 @@ instance:
             value: --requeue-dependency=5s
         target:
           kind: Deployment
-          name: (kustomize-controller|helm-controller|source-controller)
+          name: (helm-controller|source-controller)
       - # Increase the memory limits
         patch: |
           apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- limit the shared worker patch to the Helm and source controllers so only they receive --concurrent=10
- keep the kustomize controller on its dedicated --concurrent=20 patch while still replacing the temp volume

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68d34cd463d083338061721f5eb7a440