### PR TITLE
chore(ai): remove tailscale ingress from resume assistant

### DIFF
--- a/kubernetes/apps/ai/resume-assistant/README.md
+++ b/kubernetes/apps/ai/resume-assistant/README.md
@@ -12,7 +12,7 @@ Concise documentation for deploying the Resume Assistant service via Flux and th
 
 ## Overview
 
-This deployment exposes the [`ghcr.io/yamshy/resume-assistant`](https://github.com/yamshy/resume-assistant) container (tag `1.4.4`)
+This deployment exposes the [`ghcr.io/yamshy/resume-assistant`](https://github.com/yamshy/resume-assistant) container (tag `1.9.1`)
 behind Flux. Runtime configuration is supplied exclusively through the rendered ConfigMap that feeds the HelmRelease.
 
 ## Workload
@@ -27,21 +27,22 @@ behind Flux. Runtime configuration is supplied exclusively through the rendered 
 ## Networking and exposure
 
 - Service: ClusterIP on port `80` targeting the container's `8000`
-- Ingress: Tailscale ingress class
-  - Host: `resume-assistant.${SECRET_TAILNET}`
-  - TLS: secret `resume-assistant-tls`
+- Access is cluster-internal. Reach the UI from outside the cluster with a temporary port-forward, for example:
+
+  ```sh
+  kubectl -n ai port-forward svc/resume-assistant 8080:80
+  # Then open http://localhost:8080
+  ```
 
 ## Secrets & substitutions
 
 - Application API access comes from the Infisical-managed secret `resume-assistant-env`
   (`OPENAI_API_KEY` key).
-- Flux post-build substitution pulls `${SECRET_TAILNET}` from the same Infisical-managed secret so the Tailscale hostname renders correctly.
 
 ## Dependencies
 
 - Flux (Helm & Kustomize controllers)
 - Infisical Secrets Operator (manages `resume-assistant-env`)
-- Tailscale operator for the `tailscale` IngressClass
 
 ## Operations
 

--- a/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helm/values.yaml
@@ -59,23 +59,6 @@ service:
         port: 80
         protocol: TCP
         targetPort: http
-ingress:
-  app:
-    enabled: true
-    className: tailscale
-    annotations: {}
-    hosts:
-      - host: resume-assistant.${SECRET_TAILNET}
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
-    tls:
-      - secretName: resume-assistant-tls
-        hosts:
-          - resume-assistant.${SECRET_TAILNET}
 persistence:
   data:
     enabled: true

--- a/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/resume-assistant/app/helmrelease.yaml
@@ -16,9 +16,6 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  dependsOn:
-    - name: tailscale-operator
-      namespace: network
   valuesFrom:
     - kind: ConfigMap
       name: resume-assistant-values

--- a/kubernetes/apps/ai/secrets/resume-assistant-secrets.yaml
+++ b/kubernetes/apps/ai/secrets/resume-assistant-secrets.yaml
@@ -27,4 +27,3 @@ spec:
       data:
         # Only include the secrets this app actually needs
         OPENAI_API_KEY: "{{ .OPENAI_API_KEY.Value }}"
-        SECRET_TAILNET: "{{ .SECRET_TAILNET.Value }}"  # Needed for Flux substitution


### PR DESCRIPTION
## Summary
- remove the Tailscale ingress configuration from the resume-assistant Helm values and secrets bundle
- drop the HelmRelease dependency on tailscale-operator and document the new cluster-internal access pattern

## Testing
- bash scripts/validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68d351d321d483339a8c296f06eb528d