### PR TITLE
docs: require mise before validation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Use the GitOps layout to keep apps isolated and reproducible.
 Follow `.editorconfig`: YAML/JSON two spaces, shells four, Markdown four, LF endings. Use lower-kebab file and directory names (`cloudflare-tunnel`, `k8s-gateway`). Keep Helm values exclusively in `app/helm/values.yaml`, reference via `valuesFrom`, and co-locate chart sources with the `HelmRelease` unless the app already uses the shared `app-template` OCI repository.
 
 ## Testing Guidelines
-Prefer additive patches and validate locally before every PR. Run `bash scripts/validate.sh` for schema compliance and `flux-local` to catch drift. Inspect rendered manifests with `kustomize build <overlay> | yq e 'del(.sops)' -`. Ensure zero kubeconform errors and clean Flux diffs; rerun after modifying secrets or chart values.
+Prefer additive patches and validate locally before every PR. Run `mise trust && mise install` to ensure the pinned toolchain is available, then execute `bash scripts/validate.sh` for schema compliance and `flux-local` to catch drift. Inspect rendered manifests with `kustomize build <overlay> | yq e 'del(.sops)' -`. Ensure zero kubeconform errors and clean Flux diffs; rerun after modifying secrets or chart values.
 
 ## Commit & Pull Request Guidelines
 Commits follow Conventional Commits (`feat(network): add k8s-gateway`). PRs must describe changes, list impacted paths (`kubernetes/apps/...`), explain rationale, link issues, and include relevant screenshots or logs. Require green CI and passing local validation before requesting review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,11 @@ Thank you for contributing! Please follow these guidelines to help us keep quali
 
 ### Run validation before commit and PR
 - Always run repo validation locally before committing or opening a pull request.
-- In this repo, run from the repo root:
+- In this repo, trust the repo toolchain and install pinned versions before running validation:
 
 ```bash
+mise trust
+mise install
 bash scripts/validate.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Welcome to my personal homelab Kubernetes infrastructure repository! This is a p
 mise trust
 mise install
 
+# Validate manifests locally (uses the mise-managed toolchain)
+bash scripts/validate.sh
+
 # Generate Talos configuration
 task talos:generate-config
 


### PR DESCRIPTION
## Summary
- update the contributor guide and README to call mise trust/install before running the validation script
- mention the mise toolchain requirement in AGENTS.md testing guidance so local checks use the pinned tools

## Testing
- `mise trust`
- `mise install` *(fails: helm download blocked by environment networking)*
- `bash scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d3572157c48333936df4166717f7f3