### PR TITLE
feat: add resume-assistant-ui deployment with tailscale ingress

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,3 +8,4 @@ components:
 resources:
   - ./secrets/ks.yaml
   - ./resume-assistant/ks.yaml
+  - ./resume-assistant-ui/ks.yaml

--- a/kubernetes/apps/ai/resume-assistant-ui/README.md
+++ b/kubernetes/apps/ai/resume-assistant-ui/README.md
@@ -1,0 +1,65 @@
+# Resume Assistant UI (Kubernetes App)
+
+Concise documentation for deploying the Resume Assistant UI via Flux using the bjw-s app-template chart.
+
+## Quick links
+
+- Namespace: `ai`
+- Flux Kustomization: `kubernetes/apps/ai/resume-assistant-ui/ks.yaml`
+- HelmRelease: `kubernetes/apps/ai/resume-assistant-ui/app/helmrelease.yaml`
+- Chart values: `kubernetes/apps/ai/resume-assistant-ui/app/helm/values.yaml`
+- Image automation: `kubernetes/apps/ai/resume-assistant-ui/app/{imagerepository,imagepolicy}.yaml`
+
+## Overview
+
+This deployment serves the [`ghcr.io/yamshy/resume-assistant-ui`](https://github.com/yamshy/resume-assistant-ui/resume-assistant-ui) container, which hosts the Svelte-based web UI for the Resume Assistant backend. Runtime configuration is rendered through a ConfigMap that feeds the HelmRelease just like the API service.
+
+## Workload
+
+- Chart: `app-template` via the shared `app-template` OCIRepository
+- Controller: single `resume-assistant-ui` deployment managed by the chart with the default rolling update strategy
+- Resources (from values): requests `50m` CPU / `64Mi`, limits `200m` CPU / `256Mi`
+- Persistence: none (static assets only)
+
+## Networking and exposure
+
+- Service: ClusterIP on port `80` targeting the container's Nginx listener
+- Ingress: Tailscale IngressClass serves the UI at `https://resume-assistant-ui.${SECRET_TAILNET}`
+  - API calls are directed at `https://resume-assistant.${SECRET_TAILNET}` by default; adjust the secret-substituted value if the backend is exposed differently.
+
+## Dependencies
+
+- Flux (Helm & Kustomize controllers)
+- Infisical Secrets Operator (supplies `${SECRET_TAILNET}` via the shared `resume-assistant-env` secret)
+- Tailscale operator (IngressClass `tailscale`)
+
+## Operations
+
+- Trigger a reconcile:
+
+  ```sh
+  flux reconcile kustomization resume-assistant-ui -n ai
+  ```
+
+- Inspect workloads:
+
+  ```sh
+  kubectl -n ai get helmrelease,deploy,svc,ing,pod
+  ```
+
+- Edit chart values and re-run validation:
+
+  ```sh
+  $EDITOR kubernetes/apps/ai/resume-assistant-ui/app/helm/values.yaml
+  bash scripts/validate.sh
+  ```
+
+## File map
+
+- Flux Kustomization: `kubernetes/apps/ai/resume-assistant-ui/ks.yaml`
+- App manifests: `kubernetes/apps/ai/resume-assistant-ui/app/`
+  - `helmrelease.yaml` – HelmRelease definition referencing the shared `app-template` chart
+  - `helm/values.yaml` – chart values rendered via ConfigMapGenerator
+  - `helm/kustomizeconfig.yaml` – rewrites `valuesFrom` ConfigMap names
+  - `kustomization.yaml` – wires the HelmRelease, values ConfigMap, and image automation
+  - `imagerepository.yaml` / `imagepolicy.yaml` – Flux image automation resources tracking `1.x` tags

--- a/kubernetes/apps/ai/resume-assistant-ui/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/ai/resume-assistant-ui/app/helm/values.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/helm/values.yaml
@@ -1,0 +1,76 @@
+controllers:
+  resume-assistant-ui:
+    strategy: RollingUpdate
+    containers:
+      app:
+        image:
+          repository: ghcr.io/yamshy/resume-assistant-ui
+          tag: 1.0.0 # {"$imagepolicy": "ai:resume-assistant-ui-image-policy:tag"}
+        env:
+          - name: PUBLIC_LANGGRAPH_URL
+            value: "https://resume-assistant.${SECRET_TAILNET}"
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: http
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: http
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 1
+              failureThreshold: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - "ALL"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+
+service:
+  app:
+    controller: resume-assistant-ui
+    ports:
+      http:
+        port: 80
+        protocol: TCP
+        targetPort: http
+
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: resume-assistant-ui.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - resume-assistant-ui.${SECRET_TAILNET}

--- a/kubernetes/apps/ai/resume-assistant-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app resume-assistant-ui
+  namespace: ai
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: resume-assistant-ui-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/ai/resume-assistant-ui/app/imagepolicy.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/imagepolicy.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/imagepolicy-image-v1beta2.json
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: resume-assistant-ui-image-policy
+spec:
+  imageRepositoryRef:
+    name: resume-assistant-ui-image
+  policy:
+    semver:
+      range: '1.x'

--- a/kubernetes/apps/ai/resume-assistant-ui/app/imagerepository.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/imagerepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/imagerepository-source-v1beta2.json
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: resume-assistant-ui-image
+spec:
+  image: ghcr.io/yamshy/resume-assistant-ui
+  interval: 5m

--- a/kubernetes/apps/ai/resume-assistant-ui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./imagerepository.yaml
+  - ./imagepolicy.yaml
+
+configMapGenerator:
+  - name: resume-assistant-ui-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: false
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/ai/resume-assistant-ui/ks.yaml
+++ b/kubernetes/apps/ai/resume-assistant-ui/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app resume-assistant-ui
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: secrets
+      namespace: ai
+    - name: infisical-secrets-operator
+      namespace: infisical-system
+  interval: 1h
+  path: ./kubernetes/apps/ai/resume-assistant-ui/app
+  postBuild:
+    substituteFrom:
+      - name: resume-assistant-env
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/secrets/resume-assistant-secrets.yaml
+++ b/kubernetes/apps/ai/secrets/resume-assistant-secrets.yaml
@@ -27,3 +27,4 @@ spec:
       data:
         # Only include the secrets this app actually needs
         OPENAI_API_KEY: "{{ .OPENAI_API_KEY.Value }}"
+        SECRET_TAILNET: "{{ .SECRET_TAILNET.Value }}"


### PR DESCRIPTION
## Summary
- add a Flux Kustomization, Helm values, and image automation for the resume-assistant-ui frontend
- expose the UI through the Tailscale ingress class at resume-assistant-ui.${SECRET_TAILNET}
- surface SECRET_TAILNET via the shared resume-assistant Infisical secret for host substitution

## Testing
- bash scripts/validate.sh *(fails: missing required deps kustomize, kubeconform, yq)*

------
https://chatgpt.com/codex/tasks/task_e_68d425e3107c8333a4287076332b130d