### PR TITLE
ci: harden workflow tooling

### DIFF
--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -54,7 +54,7 @@ jobs:
           tmpdir="$(mktemp -d)"
           curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz" -o "${tmpdir}/yq.tar.gz"
           echo "${YQ_SHA256}  ${tmpdir}/yq.tar.gz" | sha256sum -c -
-          tar -xzf "${tmpdir}/yq.tar.gz" -C "${tmpdir}" yq_linux_amd64
+          tar -xzf "${tmpdir}/yq.tar.gz" -C "${tmpdir}" ./yq_linux_amd64
           sudo install -m 0755 "${tmpdir}/yq_linux_amd64" /usr/local/bin/yq
           yq --version
 

--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -54,7 +54,7 @@ jobs:
           tmpdir="$(mktemp -d)"
           curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz" -o "${tmpdir}/yq.tar.gz"
           echo "${YQ_SHA256}  ${tmpdir}/yq.tar.gz" | sha256sum -c -
-          tar -xzf "${tmpdir}/yq.tar.gz" -C "${tmpdir}" ./yq_linux_amd64
+          tar -xzf "${tmpdir}/yq.tar.gz" -C "${tmpdir}"
           sudo install -m 0755 "${tmpdir}/yq_linux_amd64" /usr/local/bin/yq
           yq --version
 

--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -21,20 +21,41 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install kustomize (v5.7.0)
+        env:
+          KUSTOMIZE_VERSION: v5.7.0
+          KUSTOMIZE_SHA256: 0d98f06d6d2c2c0ff8923cc136a517af74aaa187f1b9f3e17ff370d0625ede84
         run: |
-          curl -fsSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.7.0/kustomize_v5.7.0_linux_amd64.tar.gz \
-            | tar -xz && sudo mv kustomize /usr/local/bin/kustomize
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" -o "${tmpdir}/kustomize.tar.gz"
+          echo "${KUSTOMIZE_SHA256}  ${tmpdir}/kustomize.tar.gz" | sha256sum -c -
+          tar -xzf "${tmpdir}/kustomize.tar.gz" -C "${tmpdir}" kustomize
+          sudo install -m 0755 "${tmpdir}/kustomize" /usr/local/bin/kustomize
           kustomize version
 
       - name: Install kubeconform (v0.7.0)
+        env:
+          KUBECONFORM_VERSION: v0.7.0
+          KUBECONFORM_SHA256: c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3
         run: |
-          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz \
-            | tar -xz && sudo mv kubeconform /usr/local/bin/kubeconform
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" -o "${tmpdir}/kubeconform.tar.gz"
+          echo "${KUBECONFORM_SHA256}  ${tmpdir}/kubeconform.tar.gz" | sha256sum -c -
+          tar -xzf "${tmpdir}/kubeconform.tar.gz" -C "${tmpdir}" kubeconform
+          sudo install -m 0755 "${tmpdir}/kubeconform" /usr/local/bin/kubeconform
           kubeconform -v
       - name: Install yq (v4.44.1)
+        env:
+          YQ_VERSION: v4.44.1
+          YQ_SHA256: 2320004a2deaa51c9ecd8374dd3ac8f5db47dd5ce017aa203e83a41104e73eff
         run: |
-          curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64.tar.gz \
-            | tar -xz && sudo mv yq_linux_amd64 /usr/local/bin/yq
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz" -o "${tmpdir}/yq.tar.gz"
+          echo "${YQ_SHA256}  ${tmpdir}/yq.tar.gz" | sha256sum -c -
+          tar -xzf "${tmpdir}/yq.tar.gz" -C "${tmpdir}" yq_linux_amd64
+          sudo install -m 0755 "${tmpdir}/yq_linux_amd64" /usr/local/bin/yq
           yq --version
 
       - name: Build overlay list

--- a/.github/workflows/shell-and-talos-lint.yml
+++ b/.github/workflows/shell-and-talos-lint.yml
@@ -35,10 +35,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Install talhelper
+        env:
+          TALHELPER_VERSION: v3.0.35
+          TALHELPER_SHA256: 44a33a5ebe2ee63e3bdafa9ec4633bf48adc7c365d68b88d04f2bc6b0126db5b
         run: |
           set -euo pipefail
-          curl -sSL https://github.com/budimanjojo/talhelper/releases/latest/download/talhelper_linux_amd64.tar.gz -o /tmp/talhelper.tar.gz
-          tar -xzf /tmp/talhelper.tar.gz -C /tmp talhelper
-          sudo install -m 0755 /tmp/talhelper /usr/local/bin/talhelper
+          tmpdir="$(mktemp -d)"
+          curl -sSL "https://github.com/budimanjojo/talhelper/releases/download/${TALHELPER_VERSION}/talhelper_linux_amd64.tar.gz" -o "${tmpdir}/talhelper.tar.gz"
+          echo "${TALHELPER_SHA256}  ${tmpdir}/talhelper.tar.gz" | sha256sum -c -
+          tar -xzf "${tmpdir}/talhelper.tar.gz" -C "${tmpdir}" talhelper
+          sudo install -m 0755 "${tmpdir}/talhelper" /usr/local/bin/talhelper
       - name: Validate Talos configuration
         run: talhelper validate talconfig talos/talconfig.yaml --env-file talos/talenv.yaml

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -4,7 +4,7 @@ name: trufflehog-secrets-scan
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
   pull_request:
     branches: ["main"]
 
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan repository for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@27eae925deeeaf2bdad195eb197307b66596bf13 # v3.75.1
         with:
           path: ./
           extra_args: --only-verified


### PR DESCRIPTION
## Summary
- pin the Trufflehog scan action to a specific commit and run it on every branch push
- install talhelper from a versioned tarball with checksum verification
- add checksum validation when bootstrapping kustomize, kubeconform, and yq in CI

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d4606da8d48333a02a1e79b9b918ee