### PR TITLE
feat(media): add jellyfin, sonarr, and qbittorrent stack

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./infisical-system
   - ./kube-system
   - ./monitoring
+  - ./media
   - ./network
   - ./nextflow-demo
   - ./portfolio

--- a/kubernetes/apps/media/jellyfin/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/media/jellyfin/app/helm/values.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helm/values.yaml
@@ -1,0 +1,70 @@
+controllers:
+  jellyfin:
+    strategy: Recreate
+    containers:
+      app:
+        image:
+          repository: lscr.io/linuxserver/jellyfin
+          tag: 10.10.7 # pinned from LinuxServer.io Docker Hub (retrieved 2024-09)
+        env:
+          - name: PUID
+            value: "1000"
+          - name: PGID
+            value: "1000"
+          - name: TZ
+            value: America/Los_Angeles
+        ports:
+          - name: http
+            containerPort: 8096
+            protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+service:
+  app:
+    controller: jellyfin
+    ports:
+      http:
+        port: 8096
+        protocol: TCP
+        targetPort: http
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: jellyfin.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - jellyfin.${SECRET_TAILNET}
+persistence:
+  config:
+    enabled: true
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    globalMounts:
+      - path: /config
+  media:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /media
+  downloads:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /downloads

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app jellyfin
+  namespace: &namespace media
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: jellyfin-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: jellyfin-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: false
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jellyfin
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: pvc
+      namespace: media
+  interval: 1h
+  path: ./kubernetes/apps/media/jellyfin/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: media
   interval: 1h
   path: ./kubernetes/apps/media/jellyfin/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+components:
+  - ../../components/common
+resources:
+  - ./pvc/ks.yaml
+  - ./jellyfin/ks.yaml
+  - ./sonarr/ks.yaml
+  - ./qbittorrent/ks.yaml

--- a/kubernetes/apps/media/pvc/ks.yaml
+++ b/kubernetes/apps/media/pvc/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pvc
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/media/pvc
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/media/pvc/kustomization.yaml
+++ b/kubernetes/apps/media/pvc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./media-storage.yaml

--- a/kubernetes/apps/media/pvc/media-storage.yaml
+++ b/kubernetes/apps/media/pvc/media-storage.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-storage
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/media/qbittorrent/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/media/qbittorrent/app/helm/values.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helm/values.yaml
@@ -1,0 +1,70 @@
+controllers:
+  qbittorrent:
+    strategy: Recreate
+    containers:
+      app:
+        image:
+          repository: lscr.io/linuxserver/qbittorrent
+          tag: 5.1.2 # pinned from LinuxServer.io Docker Hub (retrieved 2024-09)
+        env:
+          - name: PUID
+            value: "1000"
+          - name: PGID
+            value: "1000"
+          - name: TZ
+            value: America/Los_Angeles
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+service:
+  app:
+    controller: qbittorrent
+    ports:
+      http:
+        port: 8080
+        protocol: TCP
+        targetPort: http
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: qbittorrent.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - qbittorrent.${SECRET_TAILNET}
+persistence:
+  config:
+    enabled: true
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    globalMounts:
+      - path: /config
+  media:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /media
+  downloads:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /downloads

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app qbittorrent
+  namespace: &namespace media
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: qbittorrent-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: qbittorrent-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: false
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app qbittorrent
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: pvc
+      namespace: media
+  interval: 1h
+  path: ./kubernetes/apps/media/qbittorrent/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: media
   interval: 1h
   path: ./kubernetes/apps/media/qbittorrent/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/sonarr/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/media/sonarr/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - group: helm.toolkit.fluxcd.io
+        version: v2
+        kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/kubernetes/apps/media/sonarr/app/helm/values.yaml
+++ b/kubernetes/apps/media/sonarr/app/helm/values.yaml
@@ -1,0 +1,70 @@
+controllers:
+  sonarr:
+    strategy: Recreate
+    containers:
+      app:
+        image:
+          repository: lscr.io/linuxserver/sonarr
+          tag: 4.0.15 # pinned from LinuxServer.io Docker Hub (retrieved 2024-09)
+        env:
+          - name: PUID
+            value: "1000"
+          - name: PGID
+            value: "1000"
+          - name: TZ
+            value: America/Los_Angeles
+        ports:
+          - name: http
+            containerPort: 8989
+            protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+service:
+  app:
+    controller: sonarr
+    ports:
+      http:
+        port: 8989
+        protocol: TCP
+        targetPort: http
+ingress:
+  app:
+    enabled: true
+    className: tailscale
+    hosts:
+      - host: sonarr.${SECRET_TAILNET}
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: app
+              port: http
+    tls:
+      - hosts:
+          - sonarr.${SECRET_TAILNET}
+persistence:
+  config:
+    enabled: true
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    globalMounts:
+      - path: /config
+  media:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /media
+  downloads:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: media-storage
+    globalMounts:
+      - path: /downloads

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app sonarr
+  namespace: &namespace media
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: sonarr-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: sonarr-values
+    files:
+      - values.yaml=./helm/values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: false
+
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -14,6 +14,10 @@ spec:
       namespace: media
   interval: 1h
   path: ./kubernetes/apps/media/sonarr/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sonarr
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: pvc
+      namespace: media
+  interval: 1h
+  path: ./kubernetes/apps/media/sonarr/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- add a media namespace with Flux wiring and a shared Longhorn-backed PVC
- deploy Jellyfin, Sonarr, and qBittorrent with app-template HelmReleases pinned to LinuxServer.io images
- configure shared media/download mounts and Tailscale ingress endpoints for each service

## Testing
- ⚠️ `bash scripts/validate.sh` *(missing kustomize, kubeconform, and yq in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68da089108c88333885eb3febe1f1916