### PR TITLE
feat: upgrade Nextflow to v25.04.7

### DIFF
--- a/kubernetes/apps/nextflow/nextflow-k8s-service/app/helmrelease.yaml
+++ b/kubernetes/apps/nextflow/nextflow-k8s-service/app/helmrelease.yaml
@@ -40,6 +40,7 @@ spec:
             env:
               PORT: &port 8000
               KUBECONFIG_PATH: /var/run/secrets/kubernetes.io/serviceaccount
+              NEXTFLOW_IMAGE: nextflow/nextflow:25.04.7
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Summary
- Upgrades Nextflow runtime image to v25.04.7 to resolve plugin compatibility issues
- Fixes workflow failures caused by nf-schema plugin requiring Nextflow >=24.10.0
- Previous version (24.04.6) was incompatible with latest nf-core pipelines

## Changes
- Added `NEXTFLOW_IMAGE: nextflow/nextflow:25.04.7` environment variable to nextflow-k8s-service

## Test plan
- [ ] Verify nextflow-k8s-service pod restarts successfully
- [ ] Submit a test workflow and confirm it uses Nextflow 25.04.7
- [ ] Validate nf-core/rnaseq pipeline runs without plugin version errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)