### PR TITLE
fix: correct service account in nextflow RoleBinding

### DIFF
--- a/kubernetes/apps/nextflow/nextflow/rolebinding-nextflow.yaml
+++ b/kubernetes/apps/nextflow/nextflow/rolebinding-nextflow.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: nextflow-k8s-service
 subjects:
 - kind: ServiceAccount
-  name: nextflow-k8s-service
+  name: nextflow-sa
   namespace: nextflow


### PR DESCRIPTION
## Summary
- Fixed RoleBinding to reference the correct service account `nextflow-sa` instead of the non-existent `nextflow-k8s-service`
- This resolves the issue where the nextflow-k8s-service controller would lose permissions to create and manage jobs/pods

## Problem
The RoleBinding `nextflow-k8s-service` was binding the role to a service account named `nextflow-k8s-service` which doesn't exist. The HelmRelease actually uses `nextflow-sa` (defined in `serviceaccount-nextflow-sa.yaml`), so the running pods would encounter 403 permission errors.

## Solution
Updated the RoleBinding subject to reference `nextflow-sa`, which is the actual service account used by the nextflow-k8s-service deployment.

## Test plan
- [x] Verify the service account `nextflow-sa` exists in the namespace
- [x] Confirm HelmRelease references `nextflow-sa` in its service account configuration
- [ ] Deploy and verify nextflow-k8s-service pods can create jobs and manage pods without 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)