### PR TITLE
fix: correct ServiceAccount reference in nextflow RoleBinding

### DIFF
--- a/kubernetes/apps/nextflow/nextflow/rolebinding-nextflow.yaml
+++ b/kubernetes/apps/nextflow/nextflow/rolebinding-nextflow.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: nextflow-k8s-service
 subjects:
 - kind: ServiceAccount
-  name: nextflow-sa
+  name: nextflow-k8s-service
   namespace: nextflow


### PR DESCRIPTION
## Summary
- Fixed RoleBinding to reference the correct ServiceAccount (`nextflow-k8s-service` instead of `nextflow-sa`)

## Problem
The deployment pods run with `serviceAccount: nextflow-k8s-service`, but the RoleBinding was granting permissions to `nextflow-sa`. This mismatch prevented pods from having necessary RBAC permissions to create ConfigMaps, Jobs, and other resources.

## Changes
- Updated `rolebinding-nextflow.yaml` to reference `nextflow-k8s-service` ServiceAccount

## Test plan
- [ ] Verify RoleBinding references correct ServiceAccount
- [ ] Confirm deployment pods can create ConfigMaps and Jobs
- [ ] Validate Flux reconciliation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)