### PR TITLE
fix: correct path to include nextflow_k8s_service prefix

### DIFF
--- a/kubernetes/apps/nextflow/workflow-configmaps-sync-ks.yaml
+++ b/kubernetes/apps/nextflow/workflow-configmaps-sync-ks.yaml
@@ -11,7 +11,7 @@ spec:
       app.kubernetes.io/name: *app
       app.kubernetes.io/part-of: nextflow
   interval: 5m
-  path: ./k8s-manifests/workflows
+  path: ./nextflow_k8s_service/k8s-manifests/workflows
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/nextflow_k8s_service/k8s-manifests/workflows/demo-workflow.yaml
+++ b/nextflow_k8s_service/k8s-manifests/workflows/demo-workflow.yaml
@@ -1,7 +1,7 @@
 ---
 # Placeholder for CI validation
 # At runtime, this will be replaced by content from:
-# https://github.com/yamshy/nextflow-k8s-service/tree/main/k8s-manifests/workflows
+# https://github.com/yamshy/nextflow-k8s-service/tree/main/nextflow_k8s_service/k8s-manifests/workflows
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/nextflow_k8s_service/k8s-manifests/workflows/kustomization.yaml
+++ b/nextflow_k8s_service/k8s-manifests/workflows/kustomization.yaml
@@ -3,6 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Placeholder for flux-local CI validation.
-# At runtime, Flux syncs from: https://github.com/yamshy/nextflow-k8s-service/tree/main/k8s-manifests/workflows
+# At runtime, Flux syncs from: https://github.com/yamshy/nextflow-k8s-service/tree/main/nextflow_k8s_service/k8s-manifests/workflows
 resources:
   - demo-workflow.yaml


### PR DESCRIPTION
## Summary
Fix the Flux Kustomization path to match the actual upstream repository structure.

## Problem
The previous PR (#109) pointed to `./k8s-manifests/workflows` but the actual path in the upstream repo is `./nextflow_k8s_service/k8s-manifests/workflows`.

This caused the error:
```
kustomization path not found: stat /tmp/kustomization-3615076227/k8s-manifests/workflows: no such file or directory
```

## Solution
Update path from `./k8s-manifests/workflows` to `./nextflow_k8s_service/k8s-manifests/workflows` to match upstream structure.

## Test plan
- [ ] Verify nextflow-workflow-configmaps Kustomization reconciles successfully
- [ ] Confirm demo-workflow ConfigMap is synced from upstream
- [ ] No errors in Flux reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)