### PR TITLE
chore(portfolio): bump production image to 4.37.4

### DIFF
--- a/kubernetes/apps/portfolio/portfolio-production/app/helmrelease.yaml
+++ b/kubernetes/apps/portfolio/portfolio-production/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/yamshy/portfolio
-              tag: 4.33.1
+              tag: 4.37.4
             env:
               PORT: &port 8080
             probes:


### PR DESCRIPTION
## Summary
- bump the production portfolio HelmRelease image tag to 4.37.4 to match staging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c4c2062883339f5cb6fad4f7f8d5