### PR TITLE
docs: update cloudflare-dns README for Infisical secrets

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/README.md
+++ b/kubernetes/apps/network/cloudflare-dns/README.md
@@ -7,7 +7,7 @@ Concise documentation for managing DNS via ExternalDNS with Cloudflare.
 - Namespace: `network`
 - Flux Kustomization: `kubernetes/apps/network/cloudflare-dns/ks.yaml`
 - HelmRelease: `kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml`
-- Secret (SOPS): `kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml`
+- Infisical Secrets definition: `kubernetes/apps/network/cloudflare-dns/app/secrets.infisical.yaml`
 
 ## Overview
 
@@ -28,9 +28,9 @@ Not applicable.
 ## Dependencies
 
 - Flux (Helm controller)
-- Cloudflare API token Secret:
+- Cloudflare API token Secret rendered from Infisical:
   - name: `cloudflare-dns-secret`
-  - key: `api-token`
+  - key: `CLOUDFLARE_API_TOKEN`
 - ExternalDNS CRDs and Gateway API (for HTTPRoute sources)
 
 Substitutions:
@@ -55,5 +55,5 @@ Substitutions:
 - Kustomization (Flux): `kubernetes/apps/network/cloudflare-dns/ks.yaml`
 - App manifests: `kubernetes/apps/network/cloudflare-dns/app/`
   - HelmRelease: `helmrelease.yaml`
-  - Secret (SOPS): `secret.sops.yaml`
+  - Infisical Secrets definition: `secrets.infisical.yaml`
   - Kustomization (kustomize): `kustomization.yaml`


### PR DESCRIPTION
## Summary
- update the cloudflare-dns README quick links and file map to reference `secrets.infisical.yaml`
- clarify that the Cloudflare secret is rendered from Infisical and now uses the `CLOUDFLARE_API_TOKEN` key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43e21096c8333af214844dea6613e