### PR TITLE
fix: ensure bootstrap kubeconfig output path

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -12,7 +12,7 @@ tasks:
       - talhelper genconfig
       - talhelper gencommand apply --extra-flags="--insecure" | bash
       - until talhelper gencommand bootstrap | bash; do sleep 10; done
-      - until talhelper gencommand kubeconfig --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
+      - until talhelper gencommand kubeconfig --extra-flags="--output {{.ROOT_DIR}}/kubeconfig --force" | bash; do sleep 10; done
     preconditions:
       - test -f {{.ROOT_DIR}}/.sops.yaml
       - test -f {{.SOPS_AGE_KEY_FILE}}


### PR DESCRIPTION
## Summary
- update the Talos bootstrap task to write the generated kubeconfig to the repository root so downstream tasks can find it

## Testing
- PATH=$PWD/tmpbin:$PATH ./bin/task bootstrap:talos


------
https://chatgpt.com/codex/tasks/task_e_68e43e18f29c8333a47e960577e7934a