### PR TITLE
chore: bump portfolio production image

### DIFF
--- a/kubernetes/apps/portfolio/portfolio-production/app/helmrelease.yaml
+++ b/kubernetes/apps/portfolio/portfolio-production/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/yamshy/portfolio
-              tag: 4.37.4
+              tag: 4.37.5
             env:
               PORT: &port 8080
             probes:


### PR DESCRIPTION
## Summary
- update the portfolio production HelmRelease to use the 4.37.5 image tag

## Testing
- `bash scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68e585fb9f688333b908269a6253ba55