### PR TITLE
fix(ci): add PORTFOLIO_DOMAIN environment variable to kubeconform workflow

### DIFF
--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   KUBE_VERSION: "1.33.4"
   SECRET_DOMAIN: "example.com"
+  PORTFOLIO_DOMAIN: "portfolio.example.com"
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- Adds missing `PORTFOLIO_DOMAIN` environment variable to the kubeconform CI validation workflow
- Fixes validation failure for cert-manager ClusterIssuer manifests that reference `${PORTFOLIO_DOMAIN}` in DNS zone selectors
- Aligns CI environment with local validation script (`scripts/validate.sh`)

## Test plan

- [x] CI validation should pass with proper environment variable substitution
- [x] cert-manager ClusterIssuer manifest should validate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)